### PR TITLE
Made footer visible on white background

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -16,6 +16,7 @@ html, body {
 footer {
     bottom:0px;
     width:100%;
+    text-shadow: 1px 1px 1px #000000;
 }
 
 /* Primary colour */


### PR DESCRIPTION
Before, the footer was invisible when scrolling over the white backgrounds. This problem was especially apparent on smaller viewports. This change adds a shadow to the footer, making it always visible.